### PR TITLE
feat: added self-hosted runners pipelines 

### DIFF
--- a/.github/workflows/build-conditions-inhouse.yml
+++ b/.github/workflows/build-conditions-inhouse.yml
@@ -6,7 +6,7 @@ on:
         description: 'Define the type of machine to run the job on'
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
     outputs:
       strapi:
         description: "Returns true if strapi can be built"

--- a/.github/workflows/build-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/build-with-bratiska-cli-inhouse.yml
@@ -21,7 +21,7 @@ on:
         description: 'Define the type of machine to run the job on'
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
 
     secrets:
       sentry-token:

--- a/.github/workflows/cluster-deploy-conditions-inhouse.yml
+++ b/.github/workflows/cluster-deploy-conditions-inhouse.yml
@@ -6,7 +6,7 @@ on:
         description: 'Define the type of machine to run the job on'
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
     outputs:
       dev:
         description: "Returns true if dev-strapi and dev-next can be deployed"

--- a/.github/workflows/cluster-deploy-conditions-simple-inhouse.yml
+++ b/.github/workflows/cluster-deploy-conditions-simple-inhouse.yml
@@ -6,7 +6,7 @@ on:
         description: 'Define the type of machine to run the job on'
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
     outputs:
       dev:
         description: "Returns true if dev-strapi and dev-next can be deployed"

--- a/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
@@ -51,7 +51,7 @@ on:
         description: 'Define the type of machine to run the job on'
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
 
     secrets:
       sentry-token:


### PR DESCRIPTION
* Change 'runs-on' to be taken from input of the workflow/job/step as string and then parse to object through JSON parser
* Relevant discussion https://github.com/orgs/community/discussions/26801
* This is needed if we want to switch the entire workflow to self-hosted or other then GitHub runners
* Adds '.yarn/bin' to runner PATH 