### PR TITLE
feature / backup kubernetes database

### DIFF
--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -140,12 +140,12 @@ jobs:
             echo " OK"
             
             date=$(date '+date-%Y-%m-%d-time-%H-%M-%S')
-            file="${folder}/${database}-${date}.sql"
           
             if [[ "$backup" == "shared-wordpress" ]]; then
               echo -n "  database name:"
               database=$service
               user=$service
+              file="${folder}/${database}-${date}.sql"
               echo " ${database}"
           
               echo -n "  obtaining database password..."
@@ -168,6 +168,7 @@ jobs:
                 rm -rf $folder
                 continue
               fi
+              file="${folder}/${database}-${date}.sql"
               echo " ${database}"
     
               echo -n "  creating database dump for ${database}..."


### PR DESCRIPTION
This PR is backing up databases from kubernetes to minio and in future to aws (see issue bellow).
It supports backing up postgress and shared wordpress maria db databases.

With AWS S3 we have issue with ACL permissions (`AccessControlListNotSupported: The bucket does not allow ACLs`). After it is resolved, the aws backup will start.

Tweaking for future - action which is doing upload to minio is based on some minio image which is building every time pipeline runs, which is uneffective for now. But in future we can pre build the imago to harbor and then just pull it. Sadly i havent found minio action which can upload multiple articafts/folders and it is not docker based.