### PR TITLE
New workflows for wordpress staging

### DIFF
--- a/.github/workflows/cluster-instance-command-conditions-inhouse.yml
+++ b/.github/workflows/cluster-instance-command-conditions-inhouse.yml
@@ -1,9 +1,15 @@
-name: Workflow which detects what helm instance should be deployed
+name: Workflow which detects cluster, instance and command
 on:
   workflow_call:
+    inputs:
+      runs-on:
+        description: 'Define the type of machine to run the job on'
+        type: string
+        required: false
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
     outputs:
       command:
-        description: "Helm command value"
+        description: "Command value"
         value: ${{ jobs.detect.outputs.command }}
       cluster:
         description: "cluster type as dev, staging or prod"
@@ -11,6 +17,9 @@ on:
       instance:
         description: "Returns value of instance"
         value: ${{ jobs.detect.outputs.instance }}
+      helm:
+        description: 'if commands are supported by helm'
+        value: ${{ jobs.detect.outputs.helm }}
       valuesfile:
         description: "Returns path of valuesfile"
         value: ${{ jobs.detect.outputs.valuesfile }}
@@ -18,7 +27,7 @@ on:
 jobs:
   detect:
     name: Checking deployment conditions
-    runs-on: ubuntu-latest
+    runs-on: ${{fromJSON(inputs.runs-on)}}
     outputs:
       command: ${{ steps.out.outputs.command }}
       cluster: ${{ steps.out.outputs.cluster }}
@@ -33,7 +42,7 @@ jobs:
     - name: Pipelines Version
       run: |
         echo "Pipelines version: 2.2.0"
-        
+
     - id: clean
       name: Clean tag name
       env:
@@ -61,6 +70,16 @@ jobs:
       run: |
         echo "COMMAND=${SUB%%-*}" >> $GITHUB_ENV
 
+    - id: helm
+      name: Check if commands are supported by helm
+      run: |
+        if [[( "$COMMAND" == "install"  ||  "$COMMAND" == "uninstall" || "$COMMAND" == "upgrade" )]]
+        then
+          echo "HELM=true" >> $GITHUB_ENV   
+        else
+          echo "HELM=false" >> $GITHUB_ENV 
+        fi        
+
     - id: out
       name: Set ouptuts
       run: |
@@ -68,6 +87,7 @@ jobs:
         echo "cluster=${CLUSTER}" >> $GITHUB_OUTPUT
         echo "instance=${INSTANCE}" >> $GITHUB_OUTPUT
         echo "valuesfile=deployments/${CLUSTER}/${INSTANCE}.yml" >> $GITHUB_OUTPUT
+        echo "helm=${HELM}" >> $GITHUB_OUTPUT
 
     - name: Print Outputs
       run: |
@@ -75,13 +95,14 @@ jobs:
         echo ${{ steps.out.outputs.cluster }}
         echo ${{ steps.out.outputs.instance }}
         echo ${{ steps.out.outputs.valuesfile }}
+        echo ${{ steps.out.outputs.helm }}
 
     - id: no-instance
       if: env.INSTANCE == ''
       uses: actions/github-script@v3
       with:
         script: |
-          core.setFailed(':heavy_exclamation_mark: We have no helm instances. Exiting pipeline with Fail status.')
+          core.setFailed(':heavy_exclamation_mark: We have no instance. Exiting pipeline with Fail status.')
 
     - id: no-cluster
       if: env.CLUSTER == ''
@@ -95,14 +116,14 @@ jobs:
       uses: actions/github-script@v3
       with:
         script: |
-          core.setFailed(':heavy_exclamation_mark: We have no helm command. Exiting pipeline with Fail status.')
+          core.setFailed(':heavy_exclamation_mark: We have no command. Exiting pipeline with Fail status.')
 
     - id: unsupported-command
-      if: env.COMMAND != 'install' && env.COMMAND != 'upgrade' && env.COMMAND != 'uninstall'
+      if: env.COMMAND != 'install' && env.COMMAND != 'upgrade' && env.COMMAND != 'uninstall' && env.COMMAND != 'syncfromprod'
       uses: actions/github-script@v3
       with:
         script: |
-          core.setFailed(':heavy_exclamation_mark: Unsupported helm command. Only `install`, `upgrade` and `uninstall` are supported. Exiting pipeline with Fail status.')
+          core.setFailed(`:heavy_exclamation_mark: Unsupported command "${env.COMMAND}". Only `install`, `upgrade`, `uninstall` and `syncfromprod` are supported. Exiting pipeline with Fail status.`)
 
     - id: check_files
       name: Check file existence
@@ -113,7 +134,7 @@ jobs:
 
     - name: Print info
       run: |
-        echo "## Detected helm deployment :rocket:" >> $GITHUB_STEP_SUMMARY
+        echo "## Deploy summary :rocket:" >> $GITHUB_STEP_SUMMARY
         echo ":arrow_right: Command: **${{ steps.out.outputs.command }}**" >> $GITHUB_STEP_SUMMARY
         echo ":arrow_right: Instance: **${{ steps.out.outputs.instance }}**" >> $GITHUB_STEP_SUMMARY
         echo ":arrow_right: Cluster: **${{ steps.out.outputs.cluster }}**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/remove-kubernetes-resources-inhouse.yml
+++ b/.github/workflows/remove-kubernetes-resources-inhouse.yml
@@ -1,0 +1,81 @@
+name: Remove resources from kubernetes
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Define the type of machine to run the job on'
+        type: string
+        required: false
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
+      instance:
+        description: 'Kubernetes app.kubernetes.io/instance'
+        required: true
+        type: string
+      namespace:
+        description: 'Namespace where instance can be checked by helm'
+        default: 'standalone'
+        required: true
+        type: string
+      cluster:
+        description: 'Kubernetes cluster name'
+        default: 'tkg-innov-dev'
+        required: true
+        type: string
+      url:
+        description: 'Kubernetes cluster url'
+        default: 'https://tkg.dev.bratislava.sk'
+        required: true
+        type: string
+    secrets:
+      service-account:
+        description: 'Kubernetes service account'
+        required: true
+
+jobs:
+  remove:
+    name: Remove instance resources
+    runs-on: ${{fromJSON(inputs.runs-on)}}
+    steps:
+      - name: Checking out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Pipelines Version
+        run: |
+          echo "Pipelines version: 2.2.0"
+
+      - name: Directory check
+        run: pwd
+
+      - name: Kubectl tool installer
+        uses: Azure/setup-kubectl@v4.0.0
+
+      - name: Kubernetes set service account token
+        run: kubectl config set-credentials default --token=${{ secrets.service-account }}
+
+      - name: Kubernetes set server with certificate account token
+        run: kubectl config set-cluster ${{ inputs.cluster }}  --insecure-skip-tls-verify --server=${{ inputs.url }}
+
+      - name: Kubernetes set context cluster
+        run: kubectl config set-context ${{ inputs.cluster }} --cluster=${{ inputs.cluster }} --user=default
+
+      - name: Kubernetes use context
+        run: kubectl config use-context ${{ inputs.cluster }}
+
+      - name: Helm tool installer
+        uses: azure/setup-helm@v4.1.0
+
+      - name: Helm version
+        run: helm version
+
+      - name: Print pipeline summary
+        run: |
+          echo "### Remove resources from kubernetes:" >> $GITHUB_STEP_SUMMARY
+          echo ":arrow_right: app.kubernetes.io/instance: **${{ inputs.instance }}**" >> $GITHUB_STEP_SUMMARY
+          echo ":arrow_right: Namespace: **${{ inputs.namespace }}**" >> $GITHUB_STEP_SUMMARY  
+          echo ":arrow_right: Cluster: **${{ inputs.cluster }}**" >> $GITHUB_STEP_SUMMARY  
+
+      - name: Delete instance resources
+        run: |
+          kubectl delete deployment,pod,service,statefulset,pvc,ingress,configmap,secret,ingress --namespace ${{ inputs.namespace }} --selector=app.kubernetes.io/instance=${{ inputs.instance }} --wait=true

--- a/.github/workflows/restore-from-velero-inhouse.yml
+++ b/.github/workflows/restore-from-velero-inhouse.yml
@@ -1,0 +1,102 @@
+name: Restore from velero
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Define the type of machine to run the job on'
+        type: string
+        required: false
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
+      instance:
+        description: 'Kubernetes app.kubernetes.io/instance'
+        required: true
+        type: string
+      schedule:
+        description: 'Name of velero backup schedule'
+        required: false
+        type: string
+        default: 'wordpress-backup'
+      namespace:
+        description: 'Namespace where instance can be checked by helm'
+        default: 'velero'
+        required: true
+        type: string
+      cluster:
+        description: 'Kubernetes cluster name'
+        default: 'tkg-innov-dev'
+        required: true
+        type: string
+      url:
+        description: 'Kubernetes cluster url'
+        default: 'https://tkg.dev.bratislava.sk'
+        required: true
+        type: string
+      velero:
+        description: 'Specify velero version if you need'
+        default: 'v1.13.2'
+        required: false
+        type: string
+    secrets:
+      service-account:
+        description: 'Kubernetes service account'
+        required: true
+
+jobs:
+  restore:
+    name: Restore from velero
+    runs-on: ${{fromJSON(inputs.runs-on)}}
+    steps:
+      - name: Checking out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Pipelines Version
+        run: |
+          echo "Pipelines version: 2.2.0"
+
+      - name: Directory check
+        run: pwd
+
+      - name: Kubectl tool installer
+        uses: Azure/setup-kubectl@v4.0.0
+
+      - name: Kubernetes set service account token
+        # to obtain token run: kubectl get secret <service account secret> -n=standalone -o jsonpath='{.data.token}' | base64 --decode  > token.tmp
+        run: kubectl config set-credentials default --token=${{ secrets.service-account }}
+
+      - name: Kubernetes set server with certificate account token
+        run: kubectl config set-cluster ${{ inputs.cluster }}  --insecure-skip-tls-verify --server=${{ inputs.url }}
+
+      - name: Kubernetes set context cluster
+        run: kubectl config set-context ${{ inputs.cluster }} --cluster=${{ inputs.cluster }} --user=default
+
+      - name: Kubernetes use context
+        run: kubectl config use-context ${{ inputs.cluster }}
+
+      - name: Helm tool installer
+        uses: azure/setup-helm@v4.1.0
+
+      - name: Helm version
+        run: helm version
+
+      - name: Setup velero
+        uses: skifahrer/setup-velero@v1
+        with:
+          version: 'v1.10.3'
+
+      - name: Velero version
+        run: velero version
+
+      - name: Restore from velero
+        run: |
+          # restore instance should be the same as helm instance
+          velero restore create --from-schedule ${{ inputs.schedule }} --selector app.kubernetes.io/instance=${{ inputs.instance }}
+
+      - name: Check velero logs
+        run: velero get restores --label-columns=app.kubernetes.io/instance=${{ inputs.instance }} | tail -n1
+
+      - name: Wait minute and recheck logs
+        run: |
+          sleep 60s
+          velero get restores --label-columns=app.kubernetes.io/instance=${{ inputs.instance }} | tail -n1

--- a/.github/workflows/restore-wordpress-database-from-minio-inhouse.yml
+++ b/.github/workflows/restore-wordpress-database-from-minio-inhouse.yml
@@ -1,0 +1,189 @@
+name: Restore wordpress database from DB backup
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Define the type of machine to run the job on'
+        type: string
+        required: false
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
+      instance:
+        description: 'Kubernetes app.kubernetes.io/instance'
+        required: true
+        type: string
+      namespace:
+        description: 'Namespace'
+        default: 'wordpress'
+        required: true
+        type: string
+      cluster:
+        description: 'Kubernetes cluster name'
+        default: 'tkg-innov-dev'
+        required: true
+        type: string
+      url:
+        description: 'Kubernetes cluster url'
+        default: 'https://tkg.dev.bratislava.sk'
+        required: true
+        type: string
+    secrets:
+      service-account:
+        description: 'Kubernetes service account'
+        required: true
+      minio-endpoint:
+        description: 'Minio endpoint url'
+        required: true
+      minio-access:
+        description: 'Minio access key'
+        required: true
+      minio-secret:
+        description: 'Minio secret key'
+        required: true
+      minio-bucket:
+        description: 'Minio bucket name'
+        required: true
+
+jobs:
+  restore:
+    name: Restore wordpress database from minio
+    runs-on: ${{fromJSON(inputs.runs-on)}}
+    steps:
+      - name: Checking out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Pipelines Version
+        run: |
+          echo "Pipelines version: 2.2.0"
+
+      - name: Directory check
+        run: pwd
+
+      - name: Set proper PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "/usr/bin" >> $GITHUB_PATH
+
+      - name: Kubectl tool installer
+        uses: Azure/setup-kubectl@v4.0.0
+
+      - name: Kubernetes set service account token
+        run: kubectl config set-credentials default --token=${{ secrets.service-account }}
+
+      - name: Kubernetes set server with certificate account token
+        run: kubectl config set-cluster ${{ inputs.cluster }}  --insecure-skip-tls-verify --server=${{ inputs.url }}
+
+      - name: Kubernetes set context cluster
+        run: kubectl config set-context ${{ inputs.cluster }} --cluster=${{ inputs.cluster }} --user=default
+
+      - name: Kubernetes use context
+        run: kubectl config use-context ${{ inputs.cluster }}
+
+      - name: Set env variables
+        run: |
+          echo "PROD_VALUESFILE"=deployments/prod/${{ inputs.instance }}.yml >> $GITHUB_ENV
+          echo "STAGING_VALUESFILE"=deployments/staging/${{ inputs.instance }}.yml >> $GITHUB_ENV
+          echo "UPDATEDDUMP"=db/updateddump.sql >> $GITHUB_ENV
+
+      - name: Create tmp db/ folder and set permissions
+        run: |
+          mkdir db/
+          chmod 777 db/
+
+      - name: Check if STAGING_VALUESFILE and PROD_VALUESFILE files exists
+        run: |
+          if [ ! -f ${STAGING_VALUESFILE} ]; then
+           echo " NOK - ${STAGING_VALUESFILE} is empty"
+           exit 1;
+          fi
+          echo " ${STAGING_VALUESFILE} is present"
+          
+          if [ ! -f ${PROD_VALUESFILE} ]; then
+           echo " NOK - ${PROD_VALUESFILE} is empty"
+           exit 1;
+          fi
+          echo " ${PROD_VALUESFILE} is present"
+
+      - name: Minio database download
+        uses: bratislava/minio-download-action@v1
+        with:
+          endpoint: ${{ secrets.minio-endpoint }}
+          access_key: ${{ secrets.minio-access }}
+          secret_key: ${{ secrets.minio-secret }}
+          bucket: ${{ secrets.minio-bucket }}
+          remote_path: 'tkg-innov-prod/${{ inputs.namespace }}/${{ inputs.instance }}/'
+          local_path: 'db/'
+          args: '--newer-than 2h30m --recursive'
+
+      - name: Get DB dump filename
+        run: |
+          pwd
+          file=$(find db -mindepth 1 -print -quit)
+          echo "DUMPFILE=$file" >> $GITHUB_ENV
+
+      - name: Check if DB dump was downloaded
+        run: |
+          if [ ! -f ${DUMPFILE} ]; then
+           echo " NOK - ${DUMPFILE} is empty"
+           exit 1;
+          fi
+          echo " Dumpfile was successfully downloaded"
+
+      - name: Get new hostname from values file
+        id: get_new_hostname
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.ingress.hostname' ${STAGING_VALUESFILE}
+
+      - name: Get old hostname from values file
+        id: get_old_hostname
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.ingress.hostname' ${PROD_VALUESFILE}
+
+      - name: Create MATCH and REPLACE values
+        run: |
+          echo "MATCH=(1,'siteurl','https://${{ steps.get_old_hostname.outputs.result }}','yes'),(2,'home','https://${{ steps.get_old_hostname.outputs.result }}','yes')" >> $GITHUB_ENV
+          echo "REPLACE=(1,'siteurl','https://${{ steps.get_new_hostname.outputs.result }}','yes'),(2,'home','https://${{ steps.get_new_hostname.outputs.result }}','yes')" >> $GITHUB_ENV
+
+      - name: Replace urls to new in DB Dump
+        run: |
+          sed "s#${MATCH}#${REPLACE}#g" $DUMPFILE > $UPDATEDDUMP    
+
+      - name: Set up password credentials and import database to mariadb
+        run: |
+          WORDPRESS_DB_PASSWORD=$(kubectl get secret ${{ inputs.instance }}-wordpress --namespace ${{ inputs.namespace }} -o jsonpath='{.data.WORDPRESS_DB_PASSWORD}' | base64 --decode)
+          MARIADB_ROOT_PASSWORD=$(kubectl exec --container "mariadb" --namespace "${{ inputs.namespace }}" --request-timeout=5s --insecure-skip-tls-verify "mariadb-0" -- sh -c 'echo "$MARIADB_ROOT_PASSWORD"') 
+          
+          sql_create="mysql --user=root -p\"${MARIADB_ROOT_PASSWORD}\" --execute=\"CREATE DATABASE IF NOT EXISTS ${{ inputs.instance }} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; GRANT ALL PRIVILEGES ON ${{ inputs.instance }}.* TO '${{ inputs.instance }}'@'%' IDENTIFIED BY '${WORDPRESS_DB_PASSWORD}'; FLUSH PRIVILEGES;\""
+          response_create=$(kubectl exec --container "mariadb" --namespace ${{ inputs.namespace }} --insecure-skip-tls-verify --request-timeout=5s "mariadb-0" -- sh -c "${sql_create}")
+          
+          if [[ "$response_create" != "" ]]; then
+            echo " NOK - Unable to create db and user in shared mariaDB!"
+            exit 1;
+          fi
+          echo " Users in mariaDB created."
+          
+          response_copy=$(kubectl cp ${UPDATEDDUMP} ${{ inputs.namespace }}/mariadb-0:/tmp/sql_import.sql --container "mariadb")
+          if [[ "$response_copy" != "" ]]; then
+            echo " NOK - Unable to copy db dump in shared mariaDB pod!"
+            exit 1;
+          fi
+          echo " SQL dump copied to mariaDB."
+          
+          sql_import="mysql --user=root -p\"${MARIADB_ROOT_PASSWORD}\" ${{ inputs.instance }} < /tmp/sql_import.sql"
+          response_import=$(kubectl exec --container "mariadb" --namespace ${{ inputs.namespace }} --insecure-skip-tls-verify --request-timeout=5s "mariadb-0" -- sh -c "${sql_import}")
+
+          if [[ "$response_import" != "" ]]; then
+            echo " NOK - Unable to import db in shared mariaDB!"
+            exit 1;
+          fi
+          echo " SQL dump imported to mariaDB."
+          
+          clean_dumpfile=$(kubectl exec --container "mariadb" --namespace ${{ inputs.namespace }} --insecure-skip-tls-verify --request-timeout=5s "mariadb-0" -- sh -c "rm /tmp/sql_import.sql")
+          if [[ "$clean_dumpfile" != "" ]]; then
+            echo " NOK - Unable to clean sql dump file in mariaDB!"
+            exit 1;
+          fi
+          echo " SQL dump was cleaned from mariaDB."

--- a/.github/workflows/update-wordpress-ingress-hostname-inhouse.yml
+++ b/.github/workflows/update-wordpress-ingress-hostname-inhouse.yml
@@ -1,0 +1,114 @@
+name: Update wordpress ingress hostname
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Define the type of machine to run the job on'
+        type: string
+        required: false
+        default: '["self-hosted", "Linux", "X64", "bratislava"]'
+      instance:
+        description: 'Kubernetes app.kubernetes.io/instance'
+        required: true
+        type: string
+      namespace:
+        description: 'Namespace where instance can be checked by helm'
+        default: 'wordpress'
+        required: true
+        type: string
+      cluster:
+        description: 'Kubernetes cluster name'
+        default: 'tkg-innov-dev'
+        required: true
+        type: string
+      url:
+        description: 'Kubernetes cluster url'
+        default: 'https://tkg.dev.bratislava.sk'
+        required: true
+        type: string
+    secrets:
+      service-account:
+        description: 'Kubernetes service account'
+        required: true
+
+jobs:
+  restore:
+    name: Updated hostname in ingress
+    runs-on: ${{fromJSON(inputs.runs-on)}}
+    steps:
+      - name: Checking out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Pipelines Version
+        run: |
+          echo "Pipelines version: 2.2.0"
+
+      - name: Directory check
+        run: pwd
+
+      - name: Kubectl tool installer
+        uses: Azure/setup-kubectl@v4.0.0
+
+      - name: Kubernetes set service account token
+        run: kubectl config set-credentials default --token=${{ secrets.service-account }}
+
+      - name: Kubernetes set server with certificate account token
+        run: kubectl config set-cluster ${{ inputs.cluster }}  --insecure-skip-tls-verify --server=${{ inputs.url }}
+
+      - name: Kubernetes set context cluster
+        run: kubectl config set-context ${{ inputs.cluster }} --cluster=${{ inputs.cluster }} --user=default
+
+      - name: Kubernetes use context
+        run: kubectl config use-context ${{ inputs.cluster }}
+
+      - name: Create tmp/ folder and set permissions
+        run: |
+          mkdir tmp/
+          chmod 777 tmp/
+
+      - name: Set env variables
+        run: |
+          echo "PROD_VALUESFILE"=/deployments/prod/${{ inputs.instance }}.yml >> $GITHUB_ENV
+          echo "STAGING_VALUESFILE"=/deployments/staging/${{ inputs.instance }}.yml >> $GITHUB_ENV
+          echo "OLD_INGRESS"=tmp/old_ingress.yml >> $GITHUB_ENV
+          echo "NEW_INGRESS"=tmp/new_ingress.yml >> $GITHUB_ENV
+
+      - name: Download ingress
+        run: kubectl get ingress ${{ inputs.instance }}-wordpress --namespace ${{ inputs.namespace }} -o yaml > $OLD_INGRESS
+
+      - name: Check if ingress dump was downloaded
+        run: |
+          if [ ! -f ${OLD_INGRESS} ]; then
+           echo " NOK - ${OLD_INGRESS} is empty"
+           exit 1;
+          fi
+          echo " Ingress was successfully downloaded"
+
+      - name: Get new hostname from values file
+        id: get_new_hostname
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.ingress.hostname' ${STAGING_VALUESFILE}
+
+      - name: Get old hostname from values file
+        id: get_old_hostname
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.ingress.hostname' ${PROD_VALUESFILE}
+
+      - name: Replace urls to new in DB Dump
+        run: |
+          sed "s#${{ steps.get_old_hostname.outputs.result }}#${{ steps.get_new_hostname.outputs.result }}#g" $OLD_INGRESS > $NEW_INGRESS
+
+      - name: Update ingress
+        run: kubectl apply -f $NEW_INGRESS
+
+      - name: Restart wordpress
+        run: kubectl rollout restart deployment --namespace ${{ inputs.namespace }} --selector=app.kubernetes.io/instance=${{ inputs.instance }}
+
+      - name: Print info
+        run: |
+          echo "## Staging wordpress ${{ steps.out.outputs.instance }} :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo ":arrow_right: url: **https://${{ steps.get_new_hostname.outputs.result }}**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR adds new workflows for creating wordpress staging.
It updates condtions action where is addted new command for creating a staging -> `syncfromprod`.
Then we have 4 other workflows:
- .github/workflows/remove-kubernetes-resources-inhouse.yml -> removing old instance resources 
- .github/workflows/restore-from-velero-inhouse.yml -> general workflow to restore from velero
- .github/workflows/restore-wordpress-database-from-minio-inhouse.yml -> workflow which handles wordpress database - download from minio backup, alter hostnames in wordpress settings, create users and db in shared mariadb and import dump to maria
- .github/workflows/update-wordpress-ingress-hostname-inhouse.yml -> updates ingress url to new staging url
