### PR TITLE
Enable backup pipeline to proccess a chunk of databases

### DIFF
--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -127,11 +127,11 @@ jobs:
           
           # split results based on ratio
           split=$((count / ${{ inputs.ratio }}))
-          echo "Split: ${split}"
+          echo "Numbers of pods per split: ${split}"
           echo "Part: ${{ inputs.part }}"
           
           # skips the first X of splits, then display the next split
-          select=$(echo $preselect | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split) 
+          select=$(echo $preselect | tr ' ' '\n' | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split)
           partcount=$(echo select | wc -w)
           echo "Number of pods in this part: ${partcount}"
           

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -40,6 +40,12 @@ on:
         default: 1
         required: false
         type: number
+      field-selector:
+        description: 'To better filter out the results, we have field-selector'
+        default: ''
+        required: false
+        type: string
+
     secrets:
       service-account:
         description: 'Kubernetes service account'
@@ -112,7 +118,7 @@ jobs:
           
           # we have different selects for postgress apps and for wordpress
           if [[ "$backup" == "shared-wordpress" ]]; then label="app.kubernetes.io/name=wordpress"; else label="service=database"; fi
-          preselect=$(kubectl get pod --namespace "${{ inputs.namespace }}" --insecure-skip-tls-verify --request-timeout=5s --selector "$label" --output jsonpath='{.items..metadata.name}')
+          preselect=$(kubectl get pod --namespace "${{ inputs.namespace }}" --insecure-skip-tls-verify --request-timeout=5s --selector "$label" ${{ inputs.field-selector }} --output jsonpath='{.items..metadata.name}')
           
           # Option to process just part of the pods by providing two variables
           # ratio - split to results to X parts
@@ -153,6 +159,14 @@ jobs:
           echo "Starting backup loop"
           for pod in ${select};
           do          
+          
+            # Check if the pod is in the comma-separated list of items to skip
+            if [[ "${{ inputs.skip }}" == *"$pod"* ]]; then
+            echo "Skipping pod: $pod"
+            continue
+            fi
+          
+          
             # determine service container
             container=""
             if [[ "$backup" == "shared-wordpress" ]]; then

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -123,12 +123,17 @@ jobs:
           
           # count number of pods
           count=$(echo $preselect | wc -l)
+          echo "Number of all pods: ${count}"
           
           # split results based on ratio
           split=$((count / ${{ inputs.ratio }}))
+          echo "Split: ${split}"
+          echo "Part: ${{ inputs.part }}"
           
           # skips the first X of splits, then display the next split
           select=$(echo $preselect | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split) 
+          partcount=$(echo select | wc -l)
+          echo "Number of pods in this part: ${partcount}"
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 
@@ -145,6 +150,7 @@ jobs:
           mkdir "backup"
           
           # loop in pods which are going to be backuped
+          echo "Starting backup loop"
           for pod in ${select};
           do          
             # determine service container

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -138,7 +138,7 @@ jobs:
              
           # which part from splits to display     
           part=${{ inputs.part }}    
-          echo "Part: ${part}}"     
+          echo "Part: ${part}"     
                
           # ratio for split     
           echo "Ratio: ${{ inputs.ratio }}"

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -141,11 +141,10 @@ jobs:
           echo "Part: ${part}}"     
                
           # ratio for split     
-          ratio=${{ inputs.ratio }}
-          echo "Ratio: ${ratio}"
+          echo "Ratio: ${{ inputs.ratio }}"
           
           # calculate chunk size
-          chunk=$(( (count + ratio - 1) / ratio ))
+          chunk=$(( (count + ${{ inputs.ratio }} - 1) / ${{ inputs.ratio }} ))
           echo "Chunk: ${chunk}"
          
           # Calculate how many pods to skip based on chunk size
@@ -153,7 +152,7 @@ jobs:
           echo "Skip: ${skip}"
           
           # select pods based on chunksize and skip     
-          select=$(echo $preselect | tr ' ' '\n' | tail -n +$((skip + 1)) | head -n $chunk)
+          select=$(echo "$preselect" | tail -n +$((skip + 1)) | head -n $chunk)
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -132,7 +132,7 @@ jobs:
           
           # skips the first X of splits, then display the next split
           select=$(echo $preselect | tr ' ' '\n' | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split)
-          partcount=$(echo select | wc -w)
+          partcount=$(echo select | wc -l)
           echo "Number of pods in this part: ${partcount}"
           
           # for wordpress we need to check if maria db is running

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run database backup
         id: dbbackup
-        run: |          
+        run: |
           echo "Starting..."
           backup="${{ inputs.backup }}"
           echo "We are going to backup: ${backup}"

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -107,6 +107,11 @@ jobs:
       - name: Run database backup
         id: dbbackup
         run: |
+          if [[ ${{ inputs.part }} -le 0 || ${{ inputs.ratio }} -le 0 ]]; then
+            echo "Error: Both part and ratio must be greater than 0";
+            exit 1;
+          fi
+          
           if [[ ${{ inputs.part }} -gt ${{ inputs.ratio }} ]]; then
              echo "Error: part (${{ inputs.part }}) is bigger then ratio (${{ inputs.ratio }})";
              exit 1;
@@ -130,14 +135,25 @@ jobs:
           # count number of pods
           count=$(echo $preselect | wc -w)
           echo "Number of all pods: ${count}"
+             
+          # which part from splits to display     
+          part=${{ inputs.part }}    
+          echo "Part: ${part}}"     
+               
+          # ratio for split     
+          ratio=${{ inputs.ratio }}
+          echo "Ratio: ${ratio}"
           
-          # split results based on ratio
-          split=$((count / ${{ inputs.ratio }}))
-          echo "Numbers of pods per split: ${split}"
-          echo "Part: ${{ inputs.part }}"
+          # calculate chunk size
+          chunk=$(( (count + ratio - 1) / ratio ))
+          echo "Chunk: ${chunk}"
+         
+          # Calculate how many pods to skip based on chunk size
+          skip=$(( (part - 1) * chunk ))
+          echo "Skip: ${skip}"
           
-          # skips the first X of splits, then display the next split
-          select=$(echo $preselect | tr ' ' '\n' | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split)
+          # select pods based on chunksize and skip     
+          select=$(echo $preselect | tr ' ' '\n' | tail -n +$((skip + 1)) | head -n $chunk)
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 
@@ -157,14 +173,6 @@ jobs:
           echo "Starting backup loop"
           for pod in ${select};
           do          
-          
-            # Check if the pod is in the comma-separated list of items to skip
-            if [[ "${{ inputs.skip }}" == *"$pod"* ]]; then
-            echo "Skipping pod: $pod"
-            continue
-            fi
-          
-          
             # determine service container
             container=""
             if [[ "$backup" == "shared-wordpress" ]]; then

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -138,8 +138,6 @@ jobs:
           
           # skips the first X of splits, then display the next split
           select=$(echo $preselect | tr ' ' '\n' | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split)
-          partcount=$(echo select | wc -l)
-          echo "Number of pods in this part: ${partcount}"
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -101,6 +101,11 @@ jobs:
       - name: Run database backup
         id: dbbackup
         run: |
+          if [[ ${{ inputs.part }} -gt ${{ inputs.ratio }} ]]; then
+             echo "Error: part (${{ inputs.part }}) is bigger then ratio (${{ inputs.ratio }})";
+             exit 1;
+          fi
+          
           echo "Starting..."
           backup="${{ inputs.backup }}"
           echo "We are going to backup: ${backup}"

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -100,12 +100,7 @@ jobs:
 
       - name: Run database backup
         id: dbbackup
-        run: |
-          if [[ ${{ inputs.part }} -gt ${{ inputs.ratio }} ]]; then
-              echo "Error: part (${{ inputs.part }}) is bigger then ratio (${{ inputs.ratio }})";
-              exit 1;
-          fi
-          
+        run: |          
           echo "Starting..."
           backup="${{ inputs.backup }}"
           echo "We are going to backup: ${backup}"

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -152,7 +152,6 @@ jobs:
           
           # select pods based on chunksize and skip     
           select=$(echo $preselect | tr ' ' '\n' | tail -n +$((skip + 1)) | head -n $chunk)
-          echo "These pods will be processed: ${select}"
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -137,8 +137,7 @@ jobs:
           echo "Number of all pods: ${count}"
              
           # which part from splits to display     
-          part=${{ inputs.part }}    
-          echo "Part: ${part}"     
+          echo "Part: ${{ inputs.part }}"     
                
           # ratio for split     
           echo "Ratio: ${{ inputs.ratio }}"
@@ -148,11 +147,12 @@ jobs:
           echo "Chunk: ${chunk}"
          
           # Calculate how many pods to skip based on chunk size
-          skip=$(( (part - 1) * chunk ))
+          skip=$(( (${{ inputs.part }} - 1) * chunk ))
           echo "Skip: ${skip}"
           
           # select pods based on chunksize and skip     
-          select=$(echo "$preselect" | tail -n +$((skip + 1)) | head -n $chunk)
+          select=$(echo $preselect | tr ' ' '\n' | tail -n +$((skip + 1)) | head -n $chunk)
+          echo "These pods will be processed: ${select}"
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -113,7 +113,7 @@ jobs:
           # we have different selects for postgress apps and for wordpress
           if [[ "$backup" == "shared-wordpress" ]]; then label="app.kubernetes.io/name=wordpress"; else label="service=database"; fi
           preselect=$(kubectl get pod --namespace "${{ inputs.namespace }}" --insecure-skip-tls-verify --request-timeout=5s --selector "$label" --output jsonpath='{.items..metadata.name}')
-         
+          
           # Option to process just part of the pods by providing two variables
           # ratio - split to results to X parts
           # part - which part should be displayed
@@ -122,7 +122,7 @@ jobs:
           # If you dont want to split the results, set ratio to 1 and part to 1
           
           # count number of pods
-          count=$(echo $preselect | wc -l)
+          count=$(echo $preselect | wc -w)
           echo "Number of all pods: ${count}"
           
           # split results based on ratio
@@ -132,7 +132,7 @@ jobs:
           
           # skips the first X of splits, then display the next split
           select=$(echo $preselect | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split) 
-          partcount=$(echo select | wc -l)
+          partcount=$(echo select | wc -w)
           echo "Number of pods in this part: ${partcount}"
           
           # for wordpress we need to check if maria db is running

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -30,6 +30,16 @@ on:
         default: 'https://tkg.dev.bratislava.sk'
         required: true
         type: string
+      ratio:
+        description: 'Ratio for splitting number od pods for a given processing'
+        default: 1
+        required: false
+        type: number
+      part:
+        description: 'Which part of split pods should be processed based on the ratio.'
+        default: 1
+        required: false
+        type: number
     secrets:
       service-account:
         description: 'Kubernetes service account'
@@ -90,14 +100,35 @@ jobs:
 
       - name: Run database backup
         id: dbbackup
-        run: |    
+        run: |
+          if [[ ${{ inputs.part }} -le ${{ inputs.ratio }} ]]; then
+              echo "Error: part (${{ inputs.part }}) is bigger then ratio (${{ inputs.ratio }})";
+              exit 1;
+          fi
+          
           echo "Starting..."
           backup="${{ inputs.backup }}"
           echo "We are going to backup: ${backup}"
           
           # we have different selects for postgress apps and for wordpress
           if [[ "$backup" == "shared-wordpress" ]]; then label="app.kubernetes.io/name=wordpress"; else label="service=database"; fi
-          select=$(kubectl get pod --namespace "${{ inputs.namespace }}" --insecure-skip-tls-verify --request-timeout=5s --selector "$label" --output jsonpath='{.items..metadata.name}')
+          preselect=$(kubectl get pod --namespace "${{ inputs.namespace }}" --insecure-skip-tls-verify --request-timeout=5s --selector "$label" --output jsonpath='{.items..metadata.name}')
+         
+          # Option to process just part of the pods by providing two variables
+          # ratio - split to results to X parts
+          # part - which part should be displayed
+          #
+          # Like to process first half of results, you set ratio to 2 and part to 1. To proceess second half of that set part to 2
+          # If you dont want to split the results, set ratio to 1 and part to 1
+          
+          # count number of pods
+          count=$(echo $preselect | wc -l)
+          
+          # split results based on ratio
+          split=$((count / ${{ inputs.ratio }}))
+          
+          # skips the first X of splits, then display the next split
+          select=$(echo $preselect | tail -n +$(( (${{ inputs.part }} - 1) * split + 1)) | head -n $split) 
           
           # for wordpress we need to check if maria db is running
           if [[ "$backup" == "shared-wordpress" ]]; then 

--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.4.0"
 
       - name: Directory check
         run: pwd
@@ -101,7 +101,7 @@ jobs:
       - name: Run database backup
         id: dbbackup
         run: |
-          if [[ ${{ inputs.part }} -le ${{ inputs.ratio }} ]]; then
+          if [[ ${{ inputs.part }} -gt ${{ inputs.ratio }} ]]; then
               echo "Error: part (${{ inputs.part }}) is bigger then ratio (${{ inputs.ratio }})";
               exit 1;
           fi


### PR DESCRIPTION
This PR introduces logic for the backup pipeline to run backups in smaller chunks rather than the entire namespace. There are new configurable options:

**`ratio`**: This option determines how many chunks the databases will be split into. For example, `ratio: 2` will split the databases into halves.

**`part`**: This option specifies which chunk the pipeline should process. For instance, if you split your namespace into three parts by setting `ratio: 3`, you can instruct the worker to process a specific chunk by setting `part: 1`, `part: 2`, or up to `part: 3`. The advantage of this solution is its scalability.

**`field-selector`**: If you want to specify which pods should be or not be backed this is your friend.

If you prefer not to split the select for backup, simply do not define these two variables. They have default values of `ratio: 1` and `part: 1`, meaning the pipeline will process the entire select.

This PR is related to https://github.com/bratislava/db-backup-k8s/pull/4