### PR TITLE
Added option for fetch-depth on build and deploy pipelines

### DIFF
--- a/.github/workflows/build-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/build-with-bratiska-cli-inhouse.yml
@@ -47,6 +47,11 @@ on:
         default: ''
         required: false
         type: string
+      fetch-depth:
+        description: 'Defining fetch-depth'
+        default: 0
+        required: false
+        type: number
 
     secrets:
       sentry-token:
@@ -67,11 +72,11 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.3.1"
 
       - name: Directory check
         run: pwd

--- a/.github/workflows/build-with-bratiska-cli.yml
+++ b/.github/workflows/build-with-bratiska-cli.yml
@@ -42,6 +42,11 @@ on:
         default: ''
         required: false
         type: string
+      fetch-depth:
+        description: 'Defining fetch-depth'
+        default: 0
+        required: false
+        type: number
 
     secrets:
       sentry-token:
@@ -62,11 +67,11 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.3.1"
 
       - name: Directory check
         run: pwd

--- a/.github/workflows/create-kustomize-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/create-kustomize-with-bratiska-cli-inhouse.yml
@@ -22,6 +22,11 @@ on:
         default: 'stable'
         required: false
         type: string
+      fetch-depth:
+        description: 'Defining fetch-depth'
+        default: 0
+        required: false
+        type: number
 
 jobs:
   create-kustomize-with-bratiska-cli:
@@ -34,11 +39,11 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.3.1"
 
       - name: Directory check
         run: pwd

--- a/.github/workflows/create-kustomize-with-bratiska-cli.yml
+++ b/.github/workflows/create-kustomize-with-bratiska-cli.yml
@@ -17,6 +17,11 @@ on:
         default: 'stable'
         required: false
         type: string
+      fetch-depth:
+        description: 'Defining fetch-depth'
+        default: 0
+        required: false
+        type: number
 
 jobs:
   create-kustomize-with-bratiska-cli:
@@ -29,11 +34,11 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.3.1"
 
       - name: Directory check
         run: pwd

--- a/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
@@ -62,6 +62,11 @@ on:
         default: ''
         required: false
         type: string
+      fetch-depth:
+        description: 'Defining fetch-depth'
+        default: 0
+        required: false
+        type: number
 
     secrets:
       sentry-token:
@@ -88,11 +93,11 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.3.1"
 
       - name: Directory check
         run: pwd

--- a/.github/workflows/deploy-with-bratiska-cli.yml
+++ b/.github/workflows/deploy-with-bratiska-cli.yml
@@ -57,6 +57,11 @@ on:
         default: ''
         required: false
         type: string
+      fetch-depth:
+        description: 'Defining fetch-depth'
+        default: 0
+        required: false
+        type: number
 
     secrets:
       sentry-token:
@@ -83,11 +88,11 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.0"
+          echo "Pipelines version: 2.3.1"
 
       - name: Directory check
         run: pwd


### PR DESCRIPTION
Currently, the fetch-depth value is fixed across all deploy and build pipelines. In some cases, this may slow down the pipeline when fetching such a large depth is unnecessary. This PR introduces the option to modify the fetch-depth value for both build and deploy pipelines.