### PR TITLE
Removed git fetch for bratiska cli

### DIFF
--- a/.github/workflows/build-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/build-with-bratiska-cli-inhouse.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.1"
+          echo "Pipelines version: 2.3.2"
 
       - name: Directory check
         run: pwd
@@ -103,9 +103,6 @@ jobs:
         run: |
           yarn global add bratislava/bratiska-cli#${{ inputs.version }}
           echo "~/.yarn/bin" >> $GITHUB_PATH
-
-      - name: Running git fetch for Bratiska-cli
-        run: git fetch
 
       - name: Print Bratiska-cli version
         run: bratiska-cli deploy --version

--- a/.github/workflows/build-with-bratiska-cli.yml
+++ b/.github/workflows/build-with-bratiska-cli.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.1"
+          echo "Pipelines version: 2.3.2"
 
       - name: Directory check
         run: pwd
@@ -106,9 +106,6 @@ jobs:
 
       - name: Installing Bratiska-cli version
         run: yarn global add bratislava/bratiska-cli#${{ inputs.version }}
-
-      - name: Running git fetch for Bratiska-cli
-        run: git fetch
 
       - name: Print Bratiska-cli version
         run: bratiska-cli --version

--- a/.github/workflows/create-kustomize-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/create-kustomize-with-bratiska-cli-inhouse.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.1"
+          echo "Pipelines version: 2.3.2"
 
       - name: Directory check
         run: pwd
@@ -60,9 +60,6 @@ jobs:
 
       - name: Installing Bratiska-cli version
         run: yarn global add bratislava/bratiska-cli#${{ inputs.version }}
-
-      - name: Running git fetch for Bratiska-cli
-        run: git fetch
 
       - name: Print Bratiska-cli version
         run: bratiska-cli --version

--- a/.github/workflows/create-kustomize-with-bratiska-cli.yml
+++ b/.github/workflows/create-kustomize-with-bratiska-cli.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.1"
+          echo "Pipelines version: 2.3.2"
 
       - name: Directory check
         run: pwd
@@ -55,9 +55,6 @@ jobs:
 
       - name: Installing Bratiska-cli version
         run: yarn global add bratislava/bratiska-cli#${{ inputs.version }}
-
-      - name: Running git fetch for Bratiska-cli
-        run: git fetch
 
       - name: Print Bratiska-cli version
         run: bratiska-cli --version

--- a/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.1"
+          echo "Pipelines version: 2.3.2"
 
       - name: Directory check
         run: pwd
@@ -114,13 +114,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Installing Bratiska-cli stable
+      - name: Installing Bratiska-cli ${{ inputs.version }}
         run: |
           yarn global add bratislava/bratiska-cli#${{ inputs.version }}
           echo "~/.yarn/bin" >> $GITHUB_PATH
-
-      - name: Running git fetch for Bratiska-cli
-        run: git fetch
 
       - name: Kubectl tool installer
         uses: Azure/setup-kubectl@v4.0.0

--- a/.github/workflows/deploy-with-bratiska-cli.yml
+++ b/.github/workflows/deploy-with-bratiska-cli.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.1"
+          echo "Pipelines version: 2.3.2"
 
       - name: Directory check
         run: pwd
@@ -109,11 +109,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Installing Bratiska-cli stable
+      - name: Installing Bratiska-cli ${{ inputs.version }}
         run: yarn global add bratislava/bratiska-cli#${{ inputs.version }}
-
-      - name: Running git fetch for Bratiska-cli
-        run: git fetch
 
       - name: Kubectl tool installer
         uses: Azure/setup-kubectl@v4.0.0


### PR DESCRIPTION
I found another opportunity to save time during the pipeline run. The PR removes an unnecessary step that performs git fetch, which currently takes quite a lot of time (approximately 1 minute)

Here it did run without fetch ohne probleme https://github.com/bratislava/konto.bratislava.sk/actions/runs/11033983600/job/30646450192
