### PR TITLE
added optional docker.com login

### DIFF
--- a/.github/workflows/build-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/build-with-bratiska-cli-inhouse.yml
@@ -33,8 +33,13 @@ on:
         required: false
         type: string
       username:
-        description: 'Docker username'
+        description: 'Harbor username'
         default: 'robot$github_actions'
+        required: false
+        type: string
+      docker-username:
+        description: 'Docker username'
+        default: 'bratislava'
         required: false
         type: string
       tag:
@@ -60,6 +65,9 @@ on:
       registry-pass:
         description: 'Password for registry.'
         required: false
+      docker-pass:
+        description: 'Password for docker registry.'
+        required: false
 
 jobs:
   build-with-bratiska-cli:
@@ -76,18 +84,45 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.2"
+          echo "Pipelines version: 2.4"
 
       - name: Directory check
         run: pwd
 
+      - name: Check for Harbor secret availability
+        id: harbor-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.registry-pass }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
       - name: Login to Harbor
-        if: ${{ inputs.build_image_no_registry == '' }}
+        if: ${{ steps.harbor-check.outputs.available == 'true' }}
         uses: docker/login-action@v3.1.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
           password: ${{ secrets.registry-pass }}
+
+      - name: Check for Docker secret availability
+        id: docker-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.docker-pass }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Login to Docker
+        if: ${{ steps.docker-check.outputs.available == 'true' }}
+        uses: docker/login-action@v3.1.0
+        with:
+          username: ${{ inputs.docker-username }}
+          password: ${{ secrets.docker-pass }}
 
       - name: Print pipeline summary
         run: |

--- a/.github/workflows/build-with-bratiska-cli.yml
+++ b/.github/workflows/build-with-bratiska-cli.yml
@@ -28,8 +28,13 @@ on:
         required: false
         type: string
       username:
-        description: 'Docker username'
+        description: 'Harbor username'
         default: 'robot$github_actions'
+        required: false
+        type: string
+      docker-username:
+        description: 'Docker username'
+        default: 'bratislava'
         required: false
         type: string
       tag:
@@ -55,6 +60,9 @@ on:
       registry-pass:
         description: 'Password for registry.'
         required: false
+      docker-pass:
+        description: 'Password for docker registry.'
+        required: false
 
 jobs:
   build-with-bratiska-cli:
@@ -71,13 +79,13 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.2"
+          echo "Pipelines version: 2.4"
 
       - name: Directory check
         run: pwd
 
-      - name: Check for Secret availability
-        id: secret-check
+      - name: Check for Harbor secret availability
+        id: harbor-check
         shell: bash
         run: |
           if [ "${{ secrets.registry-pass }}" != '' ]; then
@@ -87,12 +95,29 @@ jobs:
           fi
 
       - name: Login to Harbor
-        if: ${{ steps.secret-check.outputs.available == 'true' }}
+        if: ${{ steps.harbor-check.outputs.available == 'true' }}
         uses: docker/login-action@v3.1.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
           password: ${{ secrets.registry-pass }}
+
+      - name: Check for Docker secret availability
+        id: docker-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.docker-pass }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Login to Docker
+        if: ${{ steps.docker-check.outputs.available == 'true' }}
+        uses: docker/login-action@v3.1.0
+        with:
+          username: ${{ inputs.docker-username }}
+          password: ${{ secrets.docker-pass }}
 
       - name: Print pipeline summary
         run: |

--- a/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
@@ -43,7 +43,7 @@ on:
         required: true
         type: string
       username:
-        description: 'Docker username'
+        description: 'Harbor username'
         default: 'robot$github_actions'
         required: false
         type: string

--- a/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
@@ -47,6 +47,11 @@ on:
         default: 'robot$github_actions'
         required: false
         type: string
+      docker-username:
+        description: 'Docker username'
+        default: 'bratislava'
+        required: false
+        type: string
       version:
         description: 'Bratiska-cli version'
         default: 'stable'
@@ -72,15 +77,16 @@ on:
       sentry-token:
         description: 'Token used for sentry debugging.'
         required: false
-
       registry-pass:
         description: 'Password for registry where docker is uploading images'
         required: true
-        
       service-account:
         # kubectl get secret <service account secret> -n=standalone -o jsonpath='{.data.token}' | base64 --decode  > token.tmp
         description: 'Kubernetes service account'
         required: true
+      docker-pass:
+        description: 'Password for docker registry.'
+        required: false
 
 jobs:
   deploy-with-bratiska-cli:
@@ -97,7 +103,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.2"
+          echo "Pipelines version: 2.4.0"
 
       - name: Directory check
         run: pwd
@@ -141,6 +147,23 @@ jobs:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
           password: ${{ secrets.registry-pass }}
+
+      - name: Check for Docker secret availability
+        id: docker-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.docker-pass }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Login to Docker
+        if: ${{ steps.docker-check.outputs.available == 'true' }}
+        uses: docker/login-action@v3.1.0
+        with:
+          username: ${{ inputs.docker-username }}
+          password: ${{ secrets.docker-pass }}
 
       - name: Get current branch name
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy-with-bratiska-cli.yml
+++ b/.github/workflows/deploy-with-bratiska-cli.yml
@@ -38,7 +38,7 @@ on:
         required: true
         type: string
       username:
-        description: 'Docker username'
+        description: 'Harbor username'
         default: 'robot$github_actions'
         required: false
         type: string

--- a/.github/workflows/deploy-with-bratiska-cli.yml
+++ b/.github/workflows/deploy-with-bratiska-cli.yml
@@ -42,6 +42,11 @@ on:
         default: 'robot$github_actions'
         required: false
         type: string
+      docker-username:
+        description: 'Docker username'
+        default: 'bratislava'
+        required: false
+        type: string
       version:
         description: 'Bratiska-cli version'
         default: 'stable'
@@ -67,15 +72,16 @@ on:
       sentry-token:
         description: 'Token used for sentry debugging.'
         required: false
-
       registry-pass:
         description: 'Password for registry where docker is uploading images'
         required: true
-        
       service-account:
         # kubectl get secret default-token-7kvjs -n=standalone -o jsonpath='{.data.token}' | base64 --decode  > token.tmp
         description: 'Kubernetes service account'
         required: true
+      docker-pass:
+        description: 'Password for docker registry.'
+        required: false
 
 jobs:
   deploy-with-bratiska-cli:
@@ -92,7 +98,7 @@ jobs:
 
       - name: Pipelines Version
         run: |
-          echo "Pipelines version: 2.3.2"
+          echo "Pipelines version: 2.4.0"
 
       - name: Directory check
         run: pwd
@@ -134,6 +140,23 @@ jobs:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
           password: ${{ secrets.registry-pass }}
+
+      - name: Check for Docker secret availability
+        id: docker-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.docker-pass }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Login to Docker
+        if: ${{ steps.docker-check.outputs.available == 'true' }}
+        uses: docker/login-action@v3.1.0
+        with:
+          username: ${{ inputs.docker-username }}
+          password: ${{ secrets.docker-pass }}
 
       - name: Get current branch name
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This PR adds option for build and deploy pipelines to log inside docker.com This will allow us to rise our docker pull limit during our pipelines runs.
It also put on the same page optional harbor login on build bratiska pipeline which has two different versions, one on inhouse version was different then on non-inhouse (yea we should do slowly merge inhouse and noninhouse pipeline to one file)