### PR TITLE
Slack notificaitons on deploy pipelines

### DIFF
--- a/.github/workflows/build-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/build-with-bratiska-cli-inhouse.yml
@@ -57,6 +57,11 @@ on:
         default: 0
         required: false
         type: number
+      slack-channel:
+        description: 'Channel for slack notification '
+        default: "alerts-pipelines"
+        required: false
+        type: string
 
     secrets:
       sentry-token:
@@ -67,6 +72,9 @@ on:
         required: false
       docker-pass:
         description: 'Password for docker registry.'
+        required: false
+      slack-token:
+        description: 'Slackbot token'
         required: false
 
 jobs:
@@ -158,3 +166,21 @@ jobs:
           append: true
           message: |
             :partying_face: Bratiska-cli successfully built an image from path: ${{ inputs.directory }}
+
+      - name: Check for Slack secret availability
+        id: slack-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.slack-token }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Slack Report
+        if: ${{ always() && steps.slack-check.outputs.available == 'true' }}
+        uses: kpritam/slack-job-status-action@v1
+        with:
+          job-status: ${{ job.status }}
+          slack-bot-token: ${{ secrets.slack-token }}
+          channel: ${{ inputs.slack-channel }}

--- a/.github/workflows/build-with-bratiska-cli.yml
+++ b/.github/workflows/build-with-bratiska-cli.yml
@@ -52,6 +52,11 @@ on:
         default: 0
         required: false
         type: number
+      slack-channel:
+        description: 'Channel for slack notification '
+        default: "alerts-pipelines"
+        required: false
+        type: string
 
     secrets:
       sentry-token:
@@ -62,6 +67,9 @@ on:
         required: false
       docker-pass:
         description: 'Password for docker registry.'
+        required: false
+      slack-token:
+        description: 'Slackbot token'
         required: false
 
 jobs:
@@ -151,3 +159,21 @@ jobs:
           append: true
           message: |
             :partying_face: Bratiska-cli successfully built an image from path: ${{ inputs.directory }}
+
+      - name: Check for Slack secret availability
+        id: slack-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.slack-token }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Slack Report
+        if: ${{ always() && steps.slack-check.outputs.available == 'true' }}
+        uses: kpritam/slack-job-status-action@v1
+        with:
+          job-status: ${{ job.status }}
+          slack-bot-token: ${{ secrets.slack-token }}
+          channel: ${{ inputs.slack-channel }}

--- a/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
+++ b/.github/workflows/deploy-with-bratiska-cli-inhouse.yml
@@ -72,6 +72,11 @@ on:
         default: 0
         required: false
         type: number
+      slack-channel:
+        description: 'Channel for slack notification '
+        default: "alerts-pipelines"
+        required: false
+        type: string
 
     secrets:
       sentry-token:
@@ -86,6 +91,9 @@ on:
         required: true
       docker-pass:
         description: 'Password for docker registry.'
+        required: false
+      slack-token:
+        description: 'Slackbot token'
         required: false
 
 jobs:
@@ -186,3 +194,21 @@ jobs:
         run: |
           echo "###  Deployment summary :ship:" >> $GITHUB_STEP_SUMMARY
           echo ":partying_face: Bratiska-cli successfully deployed to ${{ inputs.cluster }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Check for Slack secret availability
+        id: slack-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.slack-token }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Slack Report
+        if: ${{ always() && steps.slack-check.outputs.available == 'true' }}
+        uses: kpritam/slack-job-status-action@v1
+        with:
+          job-status: ${{ job.status }}
+          slack-bot-token: ${{ secrets.slack-token }}
+          channel: ${{ inputs.slack-channel }}

--- a/.github/workflows/deploy-with-bratiska-cli.yml
+++ b/.github/workflows/deploy-with-bratiska-cli.yml
@@ -67,6 +67,11 @@ on:
         default: 0
         required: false
         type: number
+      slack-channel:
+        description: 'Channel for slack notification '
+        default: "alerts-pipelines"
+        required: false
+        type: string
 
     secrets:
       sentry-token:
@@ -81,6 +86,9 @@ on:
         required: true
       docker-pass:
         description: 'Password for docker registry.'
+        required: false
+      slack-token:
+        description: 'Slackbot token'
         required: false
 
 jobs:
@@ -179,3 +187,21 @@ jobs:
         run: |
           echo "###  Deployment summary :ship:" >> $GITHUB_STEP_SUMMARY
           echo ":partying_face: Bratiska-cli successfully deployed to ${{ inputs.cluster }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Check for Slack secret availability
+        id: slack-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.slack-token }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+          else
+          echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Slack Report
+        if: ${{ always() && steps.slack-check.outputs.available == 'true' }}
+        uses: kpritam/slack-job-status-action@v1
+        with:
+          job-status: ${{ job.status }}
+          slack-bot-token: ${{ secrets.slack-token }}
+          channel: ${{ inputs.slack-channel }}


### PR DESCRIPTION
This PR adds an option to send pipeline run statuses to a Slack channel. It introduces a new secret for the Slack bot token, which is required to post to Slack. For backward compatibility, we check for the existence of the Slack secret before running the Slack notification.