### PR TITLE
ci: pin a-sync/s3-uploader to SHA (v2.0.1)

### DIFF
--- a/.github/workflows/backup-kubernetes-databases-inhouse.yml
+++ b/.github/workflows/backup-kubernetes-databases-inhouse.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload folder to bucket
         if: inputs.aws
-        uses: a-sync/s3-uploader@master
+        uses: a-sync/s3-uploader@1b1020511c685aeb5be20f23190d2d1b63ab19a6 # v2.0.1
         with:
           args: --recursive --exclude "*.log"
         env:


### PR DESCRIPTION
## Summary
- Replace `a-sync/s3-uploader@master` (mutable branch ref) with full-SHA pin `@1b1020511c685aeb5be20f23190d2d1b63ab19a6` (tag `v2.0.1`).

## Why
`@master` follows whatever the upstream maintainer pushes next. The action runs inside `backup-kubernetes-databases-inhouse.yml` with AWS credentials available in env — a supply-chain push to upstream master would execute in our pipeline with those secrets. SHA pinning eliminates that class of risk.

`v2.0.1` is the latest tagged release; the master branch currently points at the same commit, so this PR is functionally a no-op for current behavior.

## Test plan
- [ ] `backup-kubernetes-databases-inhouse.yml` resolves the action and uploads to S3 on the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)